### PR TITLE
fix of issue #11

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -39,7 +39,8 @@ module.exports = {
           },
           {
             resolve: "gatsby-remark-copy-linked-files"
-          }
+          },
+          "gatsby-remark-autolink-headers"
         ],
         extensions: [".mdx", ".md"]
       }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "gatsby-plugin-react-helmet": "3.0.12",
     "gatsby-plugin-sharp": "^2.2.10",
     "gatsby-plugin-sitemap": "^2.0.12",
+    "gatsby-remark-autolink-headers": "^2.1.21",
     "gatsby-remark-copy-linked-files": "^2.0.11",
     "gatsby-remark-images": "3.0.10",
     "gatsby-source-filesystem": "^2.0.29",

--- a/src/components/rightSidebar.js
+++ b/src/components/rightSidebar.js
@@ -97,7 +97,7 @@ const SidebarLayout = ({ location }) => (
                     return (
                       <ListItem
                         key={index}
-                        to={`#${innerItem.title}`}
+                        to={`${innerItem.url}`}
                         level={1}
                       >
                         {innerItem.title}


### PR DESCRIPTION
1. added `gatsby-remark-autolink-headers`, which correctly sets `id`
attributes of headers
2. changed `rightSidebar.js` to use `url` instead of `title` for anchors
